### PR TITLE
adding messages to serialization errors for polymorph functionality

### DIFF
--- a/ciri/core.py
+++ b/ciri/core.py
@@ -218,7 +218,14 @@ class ABCSchema(ABCMeta):
                     for k, v in newattrs.items():
                         if callable(v):
                             if type(v) is not type:
-                                newattrs[k] = v.__get__(cls, None)
+                                try:
+                                    from types import TypeType, ClassType
+                                    if type(v) not in (TypeType, ClassType):
+                                        newattrs[k] = v.__get__(cls, None)
+                                    else:
+                                        newattrs[k] = v
+                                except Exception:
+                                    newattrs[k] = v.__get__(cls, None)
                             else:
                                 newattrs[k] = v
                     newattrs.update(attrs)
@@ -776,11 +783,18 @@ class PolySchema(AbstractPolySchema, Schema):
         id_ = data.get(ident_key)
         if not id_:
             raise SerializationError(
-                f"[{self.__class__.__name__}] Failed to find polymorphic key '{ident_key}' in input data"
+                "[{}] Failed to find polymorphic key '{}' in input data".format(
+                    self.__class__.__name__,
+                    ident_key
+                )
             )
         if not self.__poly_mapping__.get(id_):
             raise SerializationError(
-                f"[{self.__class__.__name__}] Failed to find polymorphic identifier '{id_}' in mapping {self.__poly_mapping__}"
+                "[{}] Failed to find polymorphic identifier '{}' in mapping {}".format(
+                    self.__class__.__name__,
+                    id_,
+                    self.__poly_mapping__
+                )
             )
         schema = self.__poly_mapping__.get(id_)(*self.__poly_args__, **self.__poly_kwargs__)
         return schema.deserialize(data, *args, **kwargs)
@@ -793,11 +807,18 @@ class PolySchema(AbstractPolySchema, Schema):
         id_ = data.get(ident_key)
         if not id_:
             raise SerializationError(
-                f"[{self.__class__.__name__}] Failed to find polymorphic key '{ident_key}' in input data"
+                "[{}] Failed to find polymorphic key '{}' in input data".format(
+                    self.__class__.__name__,
+                    ident_key
+                )
             )
         if not self.__poly_mapping__.get(id_):
             raise SerializationError(
-                f"[{self.__class__.__name__}] Failed to find polymorphic identifier '{id_}' in mapping {self.__poly_mapping__}"
+                "[{}] Failed to find polymorphic identifier '{}' in mapping {}".format(
+                    self.__class__.__name__,
+                    id_,
+                    self.__poly_mapping__
+                )
             )
         schema = self.__poly_mapping__.get(id_)(*self.__poly_args__, **self.__poly_kwargs__)
         return schema.serialize(data, *args, **kwargs)
@@ -810,11 +831,18 @@ class PolySchema(AbstractPolySchema, Schema):
         id_ = data.get(ident_key)
         if not id_:
             raise SerializationError(
-                f"[{self.__class__.__name__}] Failed to find polymorphic key '{ident_key}' in input data"
+                "[{}] Failed to find polymorphic key '{}' in input data".format(
+                    self.__class__.__name__,
+                    ident_key
+                )
             )
         if not self.__poly_mapping__.get(id_):
             raise SerializationError(
-                f"[{self.__class__.__name__}] Failed to find polymorphic identifier '{id_}' in mapping {self.__poly_mapping__}"
+                "[{}] Failed to find polymorphic identifier '{}' in mapping {}".format(
+                    self.__class__.__name__,
+                    id_,
+                    self.__poly_mapping__
+                )
             )
         schema = self.__poly_mapping__.get(id_)(*self.__poly_args__, **self.__poly_kwargs__)
         return schema.validate(data, *args, **kwargs)
@@ -827,11 +855,18 @@ class PolySchema(AbstractPolySchema, Schema):
         id_ = data.get(ident_key)
         if not id_:
             raise SerializationError(
-                f"[{self.__class__.__name__}] Failed to find polymorphic key '{ident_key}' in input data"
+                "[{}] Failed to find polymorphic key '{}' in input data".format(
+                    self.__class__.__name__,
+                    ident_key
+                )
             )
         if not self.__poly_mapping__.get(id_):
             raise SerializationError(
-                f"[{self.__class__.__name__}] Failed to find polymorphic identifier '{id_}' in mapping {self.__poly_mapping__}"
+                "[{}] Failed to find polymorphic identifier '{}' in mapping {}".format(
+                    self.__class__.__name__,
+                    id_,
+                    self.__poly_mapping__
+                )
             )
         schema = self.__poly_mapping__.get(id_)(*self.__poly_args__, **self.__poly_kwargs__)
         return schema.encode(data, *args, **kwargs)
@@ -850,11 +885,18 @@ class PolySchema(AbstractPolySchema, Schema):
         id_ = kwargs.get(ident_key)
         if not id_:
             raise SerializationError(
-                f"[{cls.__name__}] Failed to find polymorphic key '{ident_key}' in input data"
+                "[{}] Failed to find polymorphic key '{}' in input data".format(
+                    cls.__name__,
+                    ident_key
+                )
             )
         schema = cls.getpoly(id_)
         if not schema:
             raise SerializationError(
-                f"[{cls.__name__}] Failed to find polymorphic identifier '{id_}' in mapping {cls.__poly_mapping__}"
+                "[{}] Failed to find polymorphic identifier '{}' in mapping {}".format(
+                    cls.__name__,
+                    id_,
+                    cls.__poly_mapping__
+                )
             )
         return schema(*args, **kwargs)

--- a/ciri/core.py
+++ b/ciri/core.py
@@ -775,7 +775,13 @@ class PolySchema(AbstractPolySchema, Schema):
             data = vars(data)
         id_ = data.get(ident_key)
         if not id_:
-            raise SerializationError
+            raise SerializationError(
+                f"[{self.__class__.__name__}] Failed to find polymorphic key '{ident_key}' in input data"
+            )
+        if not self.__poly_mapping__.get(id_):
+            raise SerializationError(
+                f"[{self.__class__.__name__}] Failed to find polymorphic identifier '{id_}' in mapping {self.__poly_mapping__}"
+            )
         schema = self.__poly_mapping__.get(id_)(*self.__poly_args__, **self.__poly_kwargs__)
         return schema.deserialize(data, *args, **kwargs)
 
@@ -786,7 +792,13 @@ class PolySchema(AbstractPolySchema, Schema):
             data = vars(data)
         id_ = data.get(ident_key)
         if not id_:
-            raise SerializationError
+            raise SerializationError(
+                f"[{self.__class__.__name__}] Failed to find polymorphic key '{ident_key}' in input data"
+            )
+        if not self.__poly_mapping__.get(id_):
+            raise SerializationError(
+                f"[{self.__class__.__name__}] Failed to find polymorphic identifier '{id_}' in mapping {self.__poly_mapping__}"
+            )
         schema = self.__poly_mapping__.get(id_)(*self.__poly_args__, **self.__poly_kwargs__)
         return schema.serialize(data, *args, **kwargs)
 
@@ -797,7 +809,13 @@ class PolySchema(AbstractPolySchema, Schema):
             data = vars(data)
         id_ = data.get(ident_key)
         if not id_:
-            raise SerializationError
+            raise SerializationError(
+                f"[{self.__class__.__name__}] Failed to find polymorphic key '{ident_key}' in input data"
+            )
+        if not self.__poly_mapping__.get(id_):
+            raise SerializationError(
+                f"[{self.__class__.__name__}] Failed to find polymorphic identifier '{id_}' in mapping {self.__poly_mapping__}"
+            )
         schema = self.__poly_mapping__.get(id_)(*self.__poly_args__, **self.__poly_kwargs__)
         return schema.validate(data, *args, **kwargs)
 
@@ -808,7 +826,13 @@ class PolySchema(AbstractPolySchema, Schema):
             data = vars(data)
         id_ = data.get(ident_key)
         if not id_:
-            raise SerializationError
+            raise SerializationError(
+                f"[{self.__class__.__name__}] Failed to find polymorphic key '{ident_key}' in input data"
+            )
+        if not self.__poly_mapping__.get(id_):
+            raise SerializationError(
+                f"[{self.__class__.__name__}] Failed to find polymorphic identifier '{id_}' in mapping {self.__poly_mapping__}"
+            )
         schema = self.__poly_mapping__.get(id_)(*self.__poly_args__, **self.__poly_kwargs__)
         return schema.encode(data, *args, **kwargs)
 
@@ -824,7 +848,13 @@ class PolySchema(AbstractPolySchema, Schema):
     def polymorph(cls, *args, **kwargs):
         ident_key = cls.__poly_on__.name
         id_ = kwargs.get(ident_key)
+        if not id_:
+            raise SerializationError(
+                f"[{cls.__name__}] Failed to find polymorphic key '{ident_key}' in input data"
+            )
         schema = cls.getpoly(id_)
         if not schema:
-            raise SerializationError
+            raise SerializationError(
+                f"[{cls.__name__}] Failed to find polymorphic identifier '{id_}' in mapping {cls.__poly_mapping__}"
+            )
         return schema(*args, **kwargs)

--- a/ciri/exception.py
+++ b/ciri/exception.py
@@ -8,6 +8,7 @@ class ValidationError(Exception):
 
     def __init__(self, schema, message=None):
        self.schema = schema
+       self.message = message
 
     @property
     def errors(self):
@@ -32,5 +33,5 @@ class FieldValidationError(ValidationError):
         self.error = field_error
 
 
-class SerializationError(Exception):
+class SerializationError(SchemaException):
     pass

--- a/ciri/fields.py
+++ b/ciri/fields.py
@@ -505,9 +505,9 @@ class UUID(Field):
 
 class Child(Field):
 
-    def new(self, field, *args, path=None, **kwargs):
+    def new(self, field, *args, **kwargs):
         self.field = field
-        self.path = path
+        self.path = kwargs.pop('path', None)
         self.cache_value = SchemaFieldMissing
 
     def _get_child_value(self, value):


### PR DESCRIPTION
serialization errors usually result from missing/incorrect polymorphic information but it's often hard to tell what went wrong without a message on the exception object; this PR adds messages