### PR TITLE
Fix child field value caching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
   * Fixed parent schema mishandling load/name
   * Fixed inability to set same load key on multiple fields
   * Fixed child element errors for sub-object data
+  * Fixed child field value invaid caching
 
 
 # 0.6.0

--- a/ciri/fields.py
+++ b/ciri/fields.py
@@ -579,26 +579,24 @@ class Child(Field):
     def new(self, field, *args, **kwargs):
         self.field = field
         self.path = kwargs.pop('path', None)
-        self.cache_value = SchemaFieldMissing
 
     def _get_child_value(self, value):
-        if self.cache_value is SchemaFieldMissing:
-            ctx = val = value
-            if hasattr(ctx, '__dict__'):
-                ctx = vars(ctx)
+        ctx = value
+        if hasattr(ctx, '__dict__'):
+            ctx = vars(ctx)
+        if isinstance(ctx, dict):
             try:
                 for part in self.path.split('.'):
                     ctx = ctx.get(part, {})
                     if hasattr(ctx, '__dict__'):
                         ctx = vars(ctx)
             except AttributeError:
-                val = {}
+                pass
             try:
-                val = ctx.get(self.field.name)
+                value = ctx.get(self.field.name)
             except AttributeError:
-                val = None
-            self.cache_value = val
-        return self.cache_value
+                value = None
+        return value
 
     def serialize(self, value, **kwargs):
         if value is None and self._does_allow_none():


### PR DESCRIPTION
child field values used to be cached on the field itself, which meant that subsequent usages of that field would inherit the value (incorrectly)